### PR TITLE
プライバシーポリシーを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,10 @@
 
 </main>
 
-<footer>converTeXcel — Excel データを LaTeX / TikZ に変換するツール</footer>
+<footer>
+  <span>converTeXcel — Excel データを LaTeX / TikZ に変換するツール</span>
+  <a href="privacy.html">プライバシーポリシー</a>
+</footer>
 
 <script src="dist/convert.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.35.5/ace.js"></script>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>プライバシーポリシー — converTeXcel</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header>
+  <img class="logo" src="logo.png" alt="converTeXcel">
+  <span class="tagline">Excel / TSV データを LaTeX・CSV・TikZ グラフに変換</span>
+</header>
+
+<main style="display:block; max-width:800px; margin:32px auto; padding:0 16px;">
+
+  <div class="card full-width" style="padding:32px;">
+    <h1 style="font-size:1.4rem; font-weight:600; color:var(--green); margin-bottom:8px;">プライバシーポリシー</h1>
+    <p style="font-size:.85rem; color:var(--gray); margin-bottom:32px;">制定日：2026年5月24日</p>
+
+    <section class="policy-section">
+      <h2>はじめに</h2>
+      <p>本プライバシーポリシーは、converTeXcel（以下「本ツール」）のご利用に際して、どのような情報がどのように扱われるかを説明するものです。</p>
+    </section>
+
+    <section class="policy-section">
+      <h2>収集する情報</h2>
+      <p>本ツールは、利用者の個人情報を一切収集しません。氏名・メールアドレス・IPアドレスなどの個人を特定できる情報の収集、保存、および第三者への提供は行いません。</p>
+    </section>
+
+    <section class="policy-section">
+      <h2>データの処理</h2>
+      <p>入力されたデータ（表データ・数値など）は、すべてお使いのブラウザ上で処理されます。入力データは外部サーバーに送信されず、処理後もブラウザ外に保存されることはありません。ページを離れると入力内容は失われます。</p>
+    </section>
+
+    <section class="policy-section">
+      <h2>外部サービスの利用</h2>
+      <p>本ツールは、以下の外部サービスを利用します。</p>
+
+      <table class="policy-table">
+        <thead>
+          <tr>
+            <th>サービス</th>
+            <th>用途</th>
+            <th>送信されるデータ</th>
+            <th>利用条件</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="https://texlive.net" target="_blank" rel="noopener">texlive.net</a></td>
+            <td>LaTeX / TikZ コードの PDF コンパイル</td>
+            <td>本ツールが生成した LaTeX コード</td>
+            <td>「PDF プレビュー」ボタンを押したときのみ</td>
+          </tr>
+          <tr>
+            <td><a href="https://cdnjs.cloudflare.com" target="_blank" rel="noopener">cdnjs.cloudflare.com</a></td>
+            <td>コードエディタ（Ace）ライブラリの読み込み</td>
+            <td>なし（静的ファイルの取得のみ）</td>
+            <td>ページ読み込み時に常時</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p style="margin-top:12px;">texlive.net に送信されるのは、本ツールが生成した LaTeX コードのみです。入力元の生データがそのまま送信されることはありません。texlive.net のプライバシー取り扱いについては、同サービスの規約をご確認ください。</p>
+    </section>
+
+    <section class="policy-section">
+      <h2>Cookie・トラッキング</h2>
+      <p>本ツールは Cookie を使用しません。また、Google Analytics などのアクセス解析ツールや広告トラッキングも一切導入していません。</p>
+    </section>
+
+    <section class="policy-section">
+      <h2>ポリシーの変更</h2>
+      <p>本ポリシーは必要に応じて更新されることがあります。変更があった場合は、本ページの内容を更新します。</p>
+    </section>
+
+    <p style="margin-top:32px; font-size:.85rem; color:var(--gray);">
+      <a href="index.html" style="color:var(--green);">← トップページに戻る</a>
+    </p>
+  </div>
+
+</main>
+
+<footer>converTeXcel — Excel データを LaTeX / TikZ に変換するツール</footer>
+
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -492,6 +492,54 @@ footer {
   padding: 24px;
   font-size: .8rem;
   color: #aaa;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+footer a {
+  color: var(--green);
+  text-decoration: none;
+}
+footer a:hover {
+  text-decoration: underline;
+}
+
+/* ── Privacy page ── */
+.policy-section {
+  margin-bottom: 28px;
+}
+.policy-section h2 {
+  margin-bottom: 10px;
+}
+.policy-section p {
+  line-height: 1.7;
+  color: var(--gray-dark);
+}
+.policy-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .875rem;
+  margin-top: 12px;
+}
+.policy-table th,
+.policy-table td {
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+.policy-table th {
+  background: var(--green-light);
+  font-weight: 600;
+  color: var(--gray-dark);
+}
+.policy-table a {
+  color: var(--green);
+  text-decoration: none;
+}
+.policy-table a:hover {
+  text-decoration: underline;
 }
 
 /* ── Responsive ── */

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "convertexcel",
+  "compatibility_date": "2026-05-24",
+  "assets": {
+    "directory": "."
+  }
+}


### PR DESCRIPTION
## Summary

- `privacy.html` を新規作成（日本語プライバシーポリシーページ）
- `index.html` のフッターにプライバシーポリシーへのリンクを追加
- `style.css` にフッターリンクスタイルおよびプライバシーページ用スタイル（`.policy-section`、`.policy-table`）を追記

## 変更の背景

アプリが外部サービス（texlive.net・cdnjs.cloudflare.com）と通信しているため、利用者に対してデータの取り扱いを明示するプライバシーポリシーが必要と判断し追加。

## プライバシーポリシーの主な内容

- 個人情報は一切収集しない
- データ処理はすべてクライアントサイド（WebAssembly）で完結
- 外部サービス一覧（texlive.net：PDFプレビュー時のみ、cdnjs：Aceエディタ読み込み）
- Cookie・トラッキング不使用

## Test plan

- [ ] トップページのフッターに「プライバシーポリシー」リンクが表示される
- [ ] リンクをクリックすると `privacy.html` が正しく表示される
- [ ] 既存の変換機能（LaTeX / CSV / TikZ）に影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)