### PR TITLE
[codex] Auto preview pasted data with consent dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tools/emsdk/
 server.*.log
+dist/convert.wasm.tmp*
 
 # wrangler files
 .wrangler

--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
 <body>
 
 <header>
-  <img class="logo" src="logo.png" alt="converTeXcel">
+  <a href="https://convertexcel.net/">
+    <img class="logo" src="logo.png" alt="converTeXcel">
+  </a>
   <span class="tagline">Excel / TSV データを LaTeX・CSV・TikZ グラフに変換</span>
 </header>
 
@@ -50,16 +52,14 @@
       </div>
     </div>
 
+    <div class="auto-preview-consent" hidden>
+      <span id="auto-preview-cooldown-status" class="cooldown-status" aria-live="polite"></span>
+    </div>
+
     <details id="stats-details" hidden>
       <summary>統計量</summary>
       <div id="stats-table-container"></div>
     </details>
-
-    <div class="btn-row">
-      <button id="latex-btn" class="primary">LaTeX 変換</button>
-      <button id="csv-btn" class="primary">CSV 変換</button>
-      <button id="tikz-btn" class="primary">TikZ グラフ生成</button>
-    </div>
   </div>
 
   <!-- LaTeX 出力 -->
@@ -70,11 +70,6 @@
       <button class="copy-btn" data-target="latex">コピー</button>
     </div>
     <textarea id="latex" rows="10" placeholder="LaTeX 形式で出力されます" readonly></textarea>
-    <div class="preview-controls">
-      <button id="latex-preview-btn" class="secondary">PDF プレビュー</button>
-      <button id="latex-delete-btn" class="secondary" style="display:none;">削除</button>
-      <span id="latex-loading" class="loading-indicator">PDFをコンパイル中...</span>
-    </div>
     <div id="latex-status" class="compile-status" role="status" aria-live="polite"></div>
     <pre id="latex-log" class="compile-log" hidden></pre>
     <form id="latex-form" style="display:none;" method="post" action="https://texlive.net/cgi-bin/latexcgi" target="latex-iframe" enctype="multipart/form-data"></form>
@@ -140,8 +135,7 @@
     <textarea id="tikz" rows="12" placeholder="TikZ/PGFPlots グラフコードが出力されます"></textarea>
 
     <div class="btn-row" style="margin-top:14px">
-      <button id="tikz-preview-btn" class="secondary">PDF プレビュー</button>
-      <button id="tikz-delete-btn" class="secondary" style="display:none;">削除</button>
+      <button id="tikz-preview-btn" class="primary">PDF プレビュー更新</button>
       <span id="tikz-loading" class="loading-indicator">PDFをコンパイル中...</span>
     </div>
 
@@ -154,6 +148,18 @@
   </div>
 
 </main>
+
+<div id="pdf-consent-modal" class="modal-backdrop" hidden>
+  <div class="consent-dialog" role="dialog" aria-modal="true" aria-labelledby="pdf-consent-title">
+    <h2 id="pdf-consent-title">PDF プレビューの送信確認</h2>
+    <p>入力データと生成した PGFPlots コードを texlive.net へ送信して PDF をコンパイルします。</p>
+    <p>同意後すぐに送信し、連続送信を避けるため 15 秒間クールダウンします。</p>
+    <div class="consent-actions">
+      <button id="pdf-consent-cancel" class="secondary" type="button">キャンセル</button>
+      <button id="pdf-consent-accept" class="primary" type="button">同意して送信</button>
+    </div>
+  </div>
+</div>
 
 <footer>
   <span>converTeXcel — Excel データを LaTeX / TikZ に変換するツール</span>

--- a/privacy.html
+++ b/privacy.html
@@ -9,7 +9,9 @@
 <body>
 
 <header>
-  <img class="logo" src="logo.png" alt="converTeXcel">
+  <a href="https://convertexcel.net/">
+    <img class="logo" src="logo.png" alt="converTeXcel">
+  </a>
   <span class="tagline">Excel / TSV データを LaTeX・CSV・TikZ グラフに変換</span>
 </header>
 

--- a/script.js
+++ b/script.js
@@ -520,6 +520,7 @@ ConvertModule().then((module) => {
     csvAttachment: wrapExport('gen_csv_attachment', 'number', ['string', 'number', 'number']),
   };
   let lastGeneratedTikz = '';
+  let autoPreviewTimer = null;
 
   const runWithInput = (handler) => {
     const data = elements.input.value.trim();
@@ -538,7 +539,7 @@ ConvertModule().then((module) => {
     };
   };
 
-  document.getElementById('latex-btn').onclick = () => runWithInput((data) => {
+  const generateLatexFromInput = (data) => {
     const options = getWasmOptions();
     elements.latex.value = takeString(wasm.latexConfig(
       data,
@@ -548,9 +549,10 @@ ConvertModule().then((module) => {
       options.hasHeader,
       options.cleanInput,
     ));
-  });
+    return elements.latex.value;
+  };
 
-  document.getElementById('csv-btn').onclick = () => runWithInput((data) => {
+  const generateCsvFromInput = (data) => {
     const options = getWasmOptions();
     elements.csv.value = takeString(wasm.csvConfig(
       data,
@@ -560,7 +562,8 @@ ConvertModule().then((module) => {
       options.hasHeader,
       options.cleanInput,
     ));
-  });
+    return elements.csv.value;
+  };
 
   const generateTikzFromInput = (data) => {
     const { sigFigs, figureNumber, legendPos, scaleMode, fitMethods } = getGraphOptions();
@@ -589,47 +592,45 @@ ConvertModule().then((module) => {
     return currentBaseTikz === lastBaseTikz;
   };
 
-  elements.fitMethodsBySeries?.addEventListener('change', () => {
-    const sourceData = elements.input.value.trim();
-    if (sourceData) {
-      generateTikzFromInput(sourceData);
+  const buildCsvAttachments = (tikzCode, showAlerts = true) => {
+    const csvReferences = extractCsvReferences(tikzCode);
+    const extraFiles = [];
+    if (csvReferences.length === 0) return extraFiles;
+
+    const data = elements.input.value.trim();
+    if (!data) {
+      if (showAlerts) {
+        alert('This PGFPlots code references a CSV file. Keep the source data in the input editor before previewing.');
+      }
+      return null;
     }
-  });
 
-  document.getElementById('tikz-btn').onclick = () => runWithInput(generateTikzFromInput);
+    const { hasHeader, cleanInput } = getDataOptions();
+    const csvData = takeString(wasm.csvAttachment(data, hasHeader ? 1 : 0, cleanInput ? 1 : 0));
+    csvReferences.forEach((name) => {
+      extraFiles.push({ name, contents: csvData });
+    });
+    return extraFiles;
+  };
 
-  elements.tikzPreviewBtn.onclick = () => {
+  const previewTikzPdf = ({ showAlerts = true, forceRegenerate = false } = {}) => {
     const { figureNumber } = getGraphOptions();
     const sourceData = elements.input.value.trim();
     const currentTikz = elements.tikz.value.trim();
-    const baseTikzCode = shouldRegenerateTikzForPreview(sourceData, currentTikz)
-      ? generateTikzFromInput(sourceData)
-      : currentTikz;
+    const shouldRegenerate = forceRegenerate || shouldRegenerateTikzForPreview(sourceData, currentTikz);
+    const baseTikzCode = shouldRegenerate && sourceData ? generateTikzFromInput(sourceData) : currentTikz;
     const tikzCode = applyFigureNumber(baseTikzCode.trim(), figureNumber);
 
     if (!tikzCode) {
-      alert('TikZ code is empty. Generate or edit PGFPlots code first.');
-      return;
+      if (showAlerts) alert('TikZ code is empty. Generate or edit PGFPlots code first.');
+      return false;
     }
 
     elements.tikz.value = tikzCode;
     lastGeneratedTikz = tikzCode;
 
-    const csvReferences = extractCsvReferences(tikzCode);
-    const extraFiles = [];
-    if (csvReferences.length > 0) {
-      const data = elements.input.value.trim();
-      if (!data) {
-        alert('This PGFPlots code references a CSV file. Keep the source data in the input editor before previewing.');
-        return;
-      }
-
-      const { hasHeader, cleanInput } = getDataOptions();
-      const csvData = takeString(wasm.csvAttachment(data, hasHeader ? 1 : 0, cleanInput ? 1 : 0));
-      csvReferences.forEach((name) => {
-        extraFiles.push({ name, contents: csvData });
-      });
-    }
+    const extraFiles = buildCsvAttachments(tikzCode, showAlerts);
+    if (extraFiles === null) return false;
 
     showPdfPreview({
       preview: elements.tikzPdfPreview,
@@ -641,5 +642,49 @@ ConvertModule().then((module) => {
       log: elements.tikzLog,
     });
     submitLatexForm('tikz-form', wrapTikzDocument(tikzCode), 'uplatex', extraFiles);
+    return true;
   };
+
+  const isAutoPreviewCandidate = (data) => {
+    const lines = data.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    if (lines.length < 2) return false;
+    const delimiter = lines[0].includes('\t') ? '\t' : ',';
+    return lines[0].split(delimiter).length >= 2;
+  };
+
+  const runAutoOutputAndPreview = () => {
+    const data = elements.input.value.trim();
+    if (!isAutoPreviewCandidate(data)) return;
+    generateLatexFromInput(data);
+    generateCsvFromInput(data);
+    previewTikzPdf({ showAlerts: false, forceRegenerate: true });
+  };
+
+  const scheduleAutoOutputAndPreview = () => {
+    clearTimeout(autoPreviewTimer);
+    autoPreviewTimer = setTimeout(runAutoOutputAndPreview, 700);
+  };
+
+  document.getElementById('latex-btn').onclick = () => runWithInput(generateLatexFromInput);
+  document.getElementById('csv-btn').onclick = () => runWithInput(generateCsvFromInput);
+
+  elements.fitMethodsBySeries?.addEventListener('change', () => {
+    const sourceData = elements.input.value.trim();
+    if (sourceData) {
+      generateTikzFromInput(sourceData);
+      scheduleAutoOutputAndPreview();
+    }
+  });
+
+  document.getElementById('tikz-btn').onclick = () => runWithInput(generateTikzFromInput);
+  elements.tikzPreviewBtn.onclick = () => previewTikzPdf({ showAlerts: true });
+
+  elements.input.editor?.session.on('change', scheduleAutoOutputAndPreview);
+  textareas.input?.addEventListener('input', scheduleAutoOutputAndPreview);
+  [elements.hasHeader, elements.cleanInput, elements.decimals, elements.sigFigs, elements.filename, elements.figureNumber, elements.legendPos, elements.scaleMode]
+    .filter(Boolean)
+    .forEach((element) => element.addEventListener('change', scheduleAutoOutputAndPreview));
+  document.querySelectorAll('input[name="round-mode"]').forEach((element) => {
+    element.addEventListener('change', scheduleAutoOutputAndPreview);
+  });
 });

--- a/script.js
+++ b/script.js
@@ -54,25 +54,27 @@ const elements = {
   sigFigs: document.getElementById('sig-figs'),
   hasHeader: document.getElementById('has-header'),
   cleanInput: document.getElementById('clean-input'),
+  autoPreviewCooldownStatus: document.getElementById('auto-preview-cooldown-status'),
   filename: document.getElementById('filename'),
   figureNumber: document.getElementById('figure-number'),
   legendPos: document.getElementById('legend-pos'),
   scaleMode: document.getElementById('scale-mode'),
   fitMethodsBySeries: document.getElementById('fit-methods-by-series'),
   latexPreviewBtn: document.getElementById('latex-preview-btn'),
-  latexDeleteBtn: document.getElementById('latex-delete-btn'),
   latexLoading: document.getElementById('latex-loading'),
   latexStatus: document.getElementById('latex-status'),
   latexLog: document.getElementById('latex-log'),
   latexPdfPreview: document.getElementById('latex-pdf-preview'),
   latexIframe: document.getElementById('latex-iframe'),
   tikzPreviewBtn: document.getElementById('tikz-preview-btn'),
-  tikzDeleteBtn: document.getElementById('tikz-delete-btn'),
   tikzLoading: document.getElementById('tikz-loading'),
   tikzStatus: document.getElementById('tikz-status'),
   tikzLog: document.getElementById('tikz-log'),
   tikzPdfPreview: document.getElementById('tikz-pdf-preview'),
   tikzIframe: document.getElementById('tikz-iframe'),
+  pdfConsentModal: document.getElementById('pdf-consent-modal'),
+  pdfConsentAccept: document.getElementById('pdf-consent-accept'),
+  pdfConsentCancel: document.getElementById('pdf-consent-cancel'),
 };
 
 const readNumber = (element, fallback) => parseInt(element.value, 10) || fallback;
@@ -86,6 +88,10 @@ const getDataOptions = () => ({
   hasHeader: Boolean(elements.hasHeader?.checked),
   cleanInput: Boolean(elements.cleanInput?.checked),
 });
+
+const AUTO_PREVIEW_COOLDOWN_SECONDS = 15;
+const AUTO_PREVIEW_COOLDOWN_MS = AUTO_PREVIEW_COOLDOWN_SECONDS * 1000;
+let pdfPreviewCooldownActive = false;
 
 const fitMethodOptions = [
   ['none', 'なし（近似なし）'],
@@ -332,7 +338,7 @@ const setCompileLog = (logElement, text) => {
 };
 
 const setPreviewBusy = (previewButton, deleteButton, isBusy) => {
-  if (previewButton) previewButton.disabled = isBusy;
+  if (previewButton) previewButton.disabled = isBusy || pdfPreviewCooldownActive;
   if (deleteButton) deleteButton.disabled = isBusy;
 };
 
@@ -463,35 +469,10 @@ elements.latexPreviewBtn?.addEventListener('click', () => {
     iframe: elements.latexIframe,
     loading: elements.latexLoading,
     previewButton: elements.latexPreviewBtn,
-    deleteButton: elements.latexDeleteBtn,
     status: elements.latexStatus,
     log: elements.latexLog,
   });
   submitLatexForm('latex-form', wrapLatexDocument(texCode), 'uplatex');
-});
-
-elements.latexDeleteBtn?.addEventListener('click', () => {
-  clearPdfPreview({
-    preview: elements.latexPdfPreview,
-    iframe: elements.latexIframe,
-    loading: elements.latexLoading,
-    previewButton: elements.latexPreviewBtn,
-    deleteButton: elements.latexDeleteBtn,
-    status: elements.latexStatus,
-    log: elements.latexLog,
-  });
-});
-
-elements.tikzDeleteBtn?.addEventListener('click', () => {
-  clearPdfPreview({
-    preview: elements.tikzPdfPreview,
-    iframe: elements.tikzIframe,
-    loading: elements.tikzLoading,
-    previewButton: elements.tikzPreviewBtn,
-    deleteButton: elements.tikzDeleteBtn,
-    status: elements.tikzStatus,
-    log: elements.tikzLog,
-  });
 });
 
 const updateInputDependents = () => { updateFitMethodControls(); updateStatsDisplay(); };
@@ -521,6 +502,88 @@ ConvertModule().then((module) => {
   };
   let lastGeneratedTikz = '';
   let autoPreviewTimer = null;
+  let autoPreviewCooldownTimer = null;
+  let autoPreviewCountdownTimer = null;
+  let autoPreviewConsented = false;
+  let autoPreviewRejected = false;
+
+  const setInputLocked = (locked) => {
+    elements.input.editor?.setReadOnly(locked);
+    if (textareas.input) textareas.input.disabled = locked;
+    elements.tikzPreviewBtn && (elements.tikzPreviewBtn.disabled = locked || pdfPreviewCooldownActive);
+  };
+
+  const setCooldownStatus = (message) => {
+    if (elements.autoPreviewCooldownStatus) {
+      elements.autoPreviewCooldownStatus.textContent = message || '';
+      elements.autoPreviewCooldownStatus.closest('.auto-preview-consent').hidden = !message;
+    }
+  };
+
+  const startPdfCooldown = () => {
+    clearTimeout(autoPreviewCooldownTimer);
+    clearInterval(autoPreviewCountdownTimer);
+    pdfPreviewCooldownActive = true;
+    setInputLocked(true);
+    let remainingSeconds = AUTO_PREVIEW_COOLDOWN_SECONDS;
+    setCooldownStatus(`クールダウン中: ${remainingSeconds}秒`);
+    autoPreviewCountdownTimer = setInterval(() => {
+      remainingSeconds -= 1;
+      setCooldownStatus(remainingSeconds > 0 ? `クールダウン中: ${remainingSeconds}秒` : '');
+    }, 1000);
+    autoPreviewCooldownTimer = setTimeout(() => {
+      clearInterval(autoPreviewCountdownTimer);
+      pdfPreviewCooldownActive = false;
+      setInputLocked(false);
+      setCooldownStatus('');
+    }, AUTO_PREVIEW_COOLDOWN_MS);
+  };
+
+  const showConsentDialog = () => new Promise((resolve) => {
+    if (!elements.pdfConsentModal || !elements.pdfConsentAccept || !elements.pdfConsentCancel) {
+      resolve(window.confirm('PDF プレビューのため、入力データと生成コードを texlive.net へ送信します。同意しますか？'));
+      return;
+    }
+
+    const close = (approved) => {
+      elements.pdfConsentModal.hidden = true;
+      elements.pdfConsentAccept.removeEventListener('click', approve);
+      elements.pdfConsentCancel.removeEventListener('click', cancel);
+      document.removeEventListener('keydown', onKeyDown);
+      resolve(approved);
+    };
+    const approve = () => close(true);
+    const cancel = () => close(false);
+    const onKeyDown = (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        approve();
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cancel();
+      }
+    };
+
+    elements.pdfConsentModal.hidden = false;
+    elements.pdfConsentAccept.addEventListener('click', approve);
+    elements.pdfConsentCancel.addEventListener('click', cancel);
+    document.addEventListener('keydown', onKeyDown);
+    elements.pdfConsentAccept.focus();
+  });
+
+  const ensureAutoPreviewConsent = async () => {
+    if (autoPreviewConsented) return true;
+    if (autoPreviewRejected) return false;
+    const approved = await showConsentDialog();
+    autoPreviewConsented = approved;
+    autoPreviewRejected = !approved;
+    if (!approved) {
+      setInputLocked(true);
+      setCooldownStatus('texlive.net への送信に同意が必要です。再度使用するにはページを再読み込みしてください。');
+    }
+    return approved;
+  };
 
   const runWithInput = (handler) => {
     const data = elements.input.value.trim();
@@ -637,7 +700,6 @@ ConvertModule().then((module) => {
       iframe: elements.tikzIframe,
       loading: elements.tikzLoading,
       previewButton: elements.tikzPreviewBtn,
-      deleteButton: elements.tikzDeleteBtn,
       status: elements.tikzStatus,
       log: elements.tikzLog,
     });
@@ -652,21 +714,23 @@ ConvertModule().then((module) => {
     return lines[0].split(delimiter).length >= 2;
   };
 
-  const runAutoOutputAndPreview = () => {
+  const runAutoOutputAndPreview = async () => {
     const data = elements.input.value.trim();
     if (!isAutoPreviewCandidate(data)) return;
+    if (!(await ensureAutoPreviewConsent())) return;
+
     generateLatexFromInput(data);
     generateCsvFromInput(data);
-    previewTikzPdf({ showAlerts: false, forceRegenerate: true });
+    generateTikzFromInput(data);
+    if (previewTikzPdf({ showAlerts: false, forceRegenerate: true })) {
+      startPdfCooldown();
+    }
   };
 
   const scheduleAutoOutputAndPreview = () => {
     clearTimeout(autoPreviewTimer);
     autoPreviewTimer = setTimeout(runAutoOutputAndPreview, 700);
   };
-
-  document.getElementById('latex-btn').onclick = () => runWithInput(generateLatexFromInput);
-  document.getElementById('csv-btn').onclick = () => runWithInput(generateCsvFromInput);
 
   elements.fitMethodsBySeries?.addEventListener('change', () => {
     const sourceData = elements.input.value.trim();
@@ -676,8 +740,18 @@ ConvertModule().then((module) => {
     }
   });
 
-  document.getElementById('tikz-btn').onclick = () => runWithInput(generateTikzFromInput);
-  elements.tikzPreviewBtn.onclick = () => previewTikzPdf({ showAlerts: true });
+  elements.tikzPreviewBtn?.addEventListener('click', async () => {
+    if (pdfPreviewCooldownActive) return;
+    runWithInput(async (data) => {
+      if (!(await ensureAutoPreviewConsent())) return;
+      generateLatexFromInput(data);
+      generateCsvFromInput(data);
+      generateTikzFromInput(data);
+      if (previewTikzPdf({ showAlerts: true, forceRegenerate: true })) {
+        startPdfCooldown();
+      }
+    });
+  });
 
   elements.input.editor?.session.on('change', scheduleAutoOutputAndPreview);
   textareas.input?.addEventListener('input', scheduleAutoOutputAndPreview);

--- a/style.css
+++ b/style.css
@@ -250,6 +250,23 @@ textarea.ace-source {
   accent-color: var(--green);
 }
 
+.auto-preview-consent {
+  display: block;
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #fffdf6;
+}
+
+.cooldown-status {
+  display: block;
+  color: #6f5400;
+  font-size: .8rem;
+  font-weight: 700;
+  text-align: left;
+}
+
 .number-field {
   display: flex;
   align-items: center;
@@ -527,6 +544,51 @@ button.copy-btn:hover {
 
 /* ── Footer ── */
 /* ── Stats summary ── */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(38, 48, 42, .34);
+}
+
+.modal-backdrop[hidden] {
+  display: none;
+}
+
+.consent-dialog {
+  width: min(520px, 100%);
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: 0 18px 50px rgba(35, 56, 39, .18);
+}
+
+.consent-dialog h2 {
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--green);
+  font-size: 1rem;
+}
+
+.consent-dialog p {
+  margin-top: 10px;
+  color: var(--gray-dark);
+  font-size: .9rem;
+  line-height: 1.7;
+}
+
+.consent-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+
 #stats-details {
   margin-top: 12px;
 }
@@ -651,6 +713,12 @@ footer a:hover {
   .options-row {
     flex-direction: column;
     align-items: start;
+  }
+  .auto-preview-consent {
+    padding: 10px;
+  }
+  .cooldown-status {
+    text-align: left;
   }
   .number-field:first-of-type { margin-left: 0; }
   .tikz-controls {


### PR DESCRIPTION
## Summary

- Automatically generate LaTeX, CSV, and PGFPlots output after table data is pasted or edited.
- Add an in-app consent dialog before sending data to texlive.net for PDF preview.
- Allow Enter to accept the consent dialog, and Escape/cancel to reject it.
- Send the PDF preview immediately after consent, then enforce a fixed 15-second cooldown.
- Lock Excel data input and the PDF preview update button during cooldown, with a visible countdown.
- Remove the old conversion buttons, delete buttons, auto-preview checkbox, and editable cooldown setting.
- Ignore transient `dist/convert.wasm.tmp*` build artifacts.

## Validation

- `node --check script.js`
- Verified in the in-app browser that the consent modal is hidden initially, opens on first table input, accepts via the app-styled dialog, starts PDF preview, and shows the cooldown countdown.