### PR TITLE
[codex] Add containerized wasm build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,111 @@
 # converTeXcel
 
-## Local build
+## ローカルビルド
 
-This project builds `src/convert.cpp` into `public/dist/convert.js` and `public/dist/convert.wasm`
-with Emscripten.
+このプロジェクトは `src/convert.cpp` を Emscripten でビルドし、
+`public/dist/convert.js` と `public/dist/convert.wasm` を生成します。
 
-## Project structure
+## プロジェクト構成
 
 ```text
 .
-├── public/                 # static files served in production
-│   ├── index.html          # data conversion tool
-│   ├── stats.html          # statistics exploration tool
+├── docker-compose.yml      # emscripten/emsdk コンテナでの WASM ビルド定義
+├── public/                 # 本番で配布する静的ファイル
+│   ├── index.html          # データ変換ツール (UI)
+│   ├── convert.html
+│   ├── fit.html
+│   ├── circuit.html
+│   ├── stats.html          # 統計表示ツール
 │   ├── privacy.html
 │   ├── assets/
 │   │   ├── css/style.css
 │   │   ├── img/logo.png
 │   │   └── js/
 │   │       ├── script.js
+│   │       ├── fit.js
+│   │       ├── circuit.js
 │   │       └── stats.js
-│   └── dist/               # generated WASM bundle
-├── src/convert.cpp         # WASM conversion engine
-└── scripts/                # build and local server helpers
+│   └── dist/               # 生成された WASM バンドル
+├── src/convert.cpp         # WASM 変換エンジン
+└── scripts/                # ビルドとローカルサーバのヘルパースクリプト
 ```
 
-## Build and serve locally
+## ローカルでのビルドと起動
 
-Build WASM and start a local server in one command:
+1つのコマンドで WASM をビルドし、ローカルサーバを起動できます:
 
 ```powershell
 .\scripts\dev.ps1
 ```
 
-Open:
+ブラウザで次を開きます:
 
 ```text
 http://127.0.0.1:4173
 ```
 
-Press `Ctrl+C` to stop the server.
+停止するには `Ctrl+C` を押してください。
 
-Use a different port if needed:
+別ポートを使う場合:
 
 ```powershell
 .\scripts\dev.ps1 -Port 4174
 ```
 
-On macOS / Linux:
+ホスト環境の Emscripten を使わず、Docker Desktop の `emscripten/emsdk:latest` イメージでビルドすることもできます:
+
+```powershell
+.\scripts\build-wasm-container.ps1
+.\scripts\dev.ps1 -Container
+```
+
+または Docker Compose を使う場合:
+
+```powershell
+docker compose run --rm wasm-build
+```
+
+コンテナはこのリポジトリをコンテナ内の `/src` にマウントし、次のファイルを書き出します:
+
+```text
+public/dist/convert.js
+public/dist/convert.wasm
+```
+
+macOS / Linux の場合:
 
 ```bash
 bash scripts/dev.sh
 ```
 
+macOS / Linux でコンテナビルドする例:
+
+```bash
+bash scripts/build-wasm-container.sh
+USE_CONTAINER=1 bash scripts/dev.sh
+```
+
+macOS / Linux でも Docker Compose は同様に動作します:
+
+```bash
+docker compose run --rm wasm-build
+```
+
+必要に応じて別イメージタグやランタイムを指定できます:
+
+```powershell
+.\scripts\build-wasm-container.ps1 -Image emscripten/emsdk:latest -Runtime docker
+```
+
+または:
+
+```bash
+EMSDK_IMAGE=emscripten/emsdk:latest CONTAINER_RUNTIME=docker bash scripts/build-wasm-container.sh
+```
+
 ### Windows PowerShell
 
-Install and activate Emscripten:
+Emscripten をインストールして有効化する手順:
 
 ```powershell
 git clone https://github.com/emscripten-core/emsdk.git
@@ -64,17 +115,17 @@ cd emsdk
 .\emsdk_env.ps1
 ```
 
-Build from the project root:
+プロジェクトルートからビルドします:
 
 ```powershell
 .\scripts\build-wasm.ps1
 ```
 
-If `tools/emsdk` exists in this project, the script activates it automatically.
+プロジェクト内に `tools/emsdk` が存在する場合、スクリプトはそれを自動で有効化します。
 
 ### macOS / Linux
 
-Install and activate Emscripten:
+Emscripten をインストールして有効化する手順:
 
 ```bash
 git clone https://github.com/emscripten-core/emsdk.git
@@ -84,13 +135,13 @@ cd emsdk
 source ./emsdk_env.sh
 ```
 
-Build from the project root:
+プロジェクトルートからビルドします:
 
 ```bash
 bash scripts/build-wasm.sh
 ```
 
-If `tools/emsdk` exists in this project, the script activates it automatically.
+プロジェクト内に `tools/emsdk` が存在する場合、スクリプトはそれを自動で有効化します。
 
-The GitHub Actions workflow uses the same shell script, so local builds and CI
-builds export the same WASM functions.
+GitHub Actions のワークフローは同じシェルスクリプトを使うため、ローカルと CI で同じ WASM 関数がエクスポートされます。
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  wasm-build:
+    image: emscripten/emsdk:latest
+    working_dir: /src
+    volumes:
+      - .:/src
+    command:
+      - emcc
+      - src/convert.cpp
+      - -O3
+      - -s
+      - WASM=1
+      - -s
+      - MODULARIZE=1
+      - -s
+      - EXPORT_NAME=ConvertModule
+      - -s
+      - EXPORTED_FUNCTIONS=[_gen_latex,_gen_csv,_gen_csv_rounded,_gen_csv_sig_figs,_gen_latex_rounded,_gen_latex_sig_figs,_gen_tikz_graph,_gen_tikz_graph_preview,_gen_latex_config,_gen_csv_config,_gen_tikz_graph_config,_gen_csv_attachment,_free]
+      - -s
+      - EXPORTED_RUNTIME_METHODS=["cwrap","UTF8ToString"]
+      - -o
+      - public/dist/convert.js

--- a/scripts/build-wasm-container.ps1
+++ b/scripts/build-wasm-container.ps1
@@ -1,0 +1,51 @@
+param(
+  [string]$Source = "src/convert.cpp",
+  [string]$OutDir = "public/dist",
+  [string]$Image = "emscripten/emsdk:latest",
+  [string]$Runtime = "docker"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command $Runtime -ErrorAction SilentlyContinue)) {
+  Write-Error "$Runtime was not found. Start Docker Desktop or install a compatible container runtime."
+}
+
+$root = Resolve-Path (Join-Path $PSScriptRoot "..")
+$sourcePath = Join-Path $root $Source
+if (-not (Test-Path $sourcePath)) {
+  Write-Error "Source file was not found: $Source"
+}
+
+New-Item -ItemType Directory -Force -Path (Join-Path $root $OutDir) | Out-Null
+
+$exportedFunctions = @(
+  "_gen_latex",
+  "_gen_csv",
+  "_gen_csv_rounded",
+  "_gen_csv_sig_figs",
+  "_gen_latex_rounded",
+  "_gen_latex_sig_figs",
+  "_gen_tikz_graph",
+  "_gen_tikz_graph_preview",
+  "_gen_latex_config",
+  "_gen_csv_config",
+  "_gen_tikz_graph_config",
+  "_gen_csv_attachment",
+  "_free"
+) -join ","
+
+$containerSource = $Source -replace "\\", "/"
+$containerOut = (($OutDir -replace "\\", "/").TrimEnd("/")) + "/convert.js"
+
+& $Runtime run --rm `
+  -v "${root}:/src" `
+  -w /src `
+  $Image `
+  emcc $containerSource -O3 `
+    -s WASM=1 `
+    -s MODULARIZE=1 `
+    -s EXPORT_NAME=ConvertModule `
+    -s "EXPORTED_FUNCTIONS=[$exportedFunctions]" `
+    -s 'EXPORTED_RUNTIME_METHODS=["cwrap","UTF8ToString"]' `
+    -o $containerOut

--- a/scripts/build-wasm-container.sh
+++ b/scripts/build-wasm-container.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="${1:-src/convert.cpp}"
+out_dir="${2:-public/dist}"
+image="${EMSDK_IMAGE:-emscripten/emsdk:latest}"
+runtime="${CONTAINER_RUNTIME:-docker}"
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v "$runtime" >/dev/null 2>&1; then
+  echo "$runtime was not found. Start Docker Desktop or install a compatible container runtime." >&2
+  exit 1
+fi
+
+if [ ! -f "$root_dir/$source_file" ]; then
+  echo "Source file was not found: $source_file" >&2
+  exit 1
+fi
+
+mkdir -p "$root_dir/$out_dir"
+
+"$runtime" run --rm \
+  -v "$root_dir:/src" \
+  -w /src \
+  "$image" \
+  emcc "$source_file" -O3 \
+    -s WASM=1 \
+    -s MODULARIZE=1 \
+    -s EXPORT_NAME=ConvertModule \
+    -s 'EXPORTED_FUNCTIONS=[_gen_latex,_gen_csv,_gen_csv_rounded,_gen_csv_sig_figs,_gen_latex_rounded,_gen_latex_sig_figs,_gen_tikz_graph,_gen_tikz_graph_preview,_gen_latex_config,_gen_csv_config,_gen_tikz_graph_config,_gen_csv_attachment,_free]' \
+    -s 'EXPORTED_RUNTIME_METHODS=["cwrap","UTF8ToString"]' \
+    -o "$out_dir/convert.js"

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,13 +1,18 @@
 param(
   [int]$Port = 4173,
-  [string]$HostName = "127.0.0.1"
+  [string]$HostName = "127.0.0.1",
+  [switch]$Container
 )
 
 $ErrorActionPreference = "Stop"
 
 Push-Location (Join-Path $PSScriptRoot "..")
 try {
-  & (Join-Path $PSScriptRoot "build-wasm.ps1")
+  if ($Container) {
+    & (Join-Path $PSScriptRoot "build-wasm-container.ps1")
+  } else {
+    & (Join-Path $PSScriptRoot "build-wasm.ps1")
+  }
 
   $env:PORT = $Port.ToString()
   $env:HOST = $HostName

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -4,9 +4,14 @@ set -euo pipefail
 port="${PORT:-4173}"
 host="${HOST:-127.0.0.1}"
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+use_container="${USE_CONTAINER:-0}"
 
 cd "$root_dir"
-bash scripts/build-wasm.sh
+if [ "$use_container" = "1" ]; then
+  bash scripts/build-wasm-container.sh
+else
+  bash scripts/build-wasm.sh
+fi
 
 echo "Serving http://${host}:${port}"
 echo "Press Ctrl+C to stop."


### PR DESCRIPTION
## Summary
- add Docker Compose support using emscripten/emsdk:latest directly
- add Windows and Unix container build scripts
- let dev scripts build through the container path when requested
- update README with current local and container build steps

## Validation
- docker compose run --rm wasm-build
- Node smoke test loading public/dist/convert.js and calling gen_csv