### PR TITLE
[codex] Improve frontend loading performance

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react"
 import { BrowserRouter, Route, Routes } from "react-router-dom"
 
 import { AppHeader } from "@/components/AppHeader"
@@ -5,10 +6,11 @@ import { StatusBar } from "@/components/StatusBar"
 import { I18nProvider } from "@/hooks/useI18n"
 import { StatusBarProvider } from "@/hooks/useStatusBar"
 import { LANGUAGE_PATH_SEGMENTS, SUPPORTED_LANGUAGES } from "@/lib/i18n"
-import AddinPage from "@/pages/AddinPage"
-import ConvertPage from "@/pages/ConvertPage"
-import NotFoundPage from "@/pages/NotFoundPage"
-import PrivacyPage from "@/pages/PrivacyPage"
+
+const AddinPage = lazy(() => import("@/pages/AddinPage"))
+const ConvertPage = lazy(() => import("@/pages/ConvertPage"))
+const NotFoundPage = lazy(() => import("@/pages/NotFoundPage"))
+const PrivacyPage = lazy(() => import("@/pages/PrivacyPage"))
 
 const localizedRoutes = SUPPORTED_LANGUAGES
   .filter((language) => language !== "ja")
@@ -29,14 +31,16 @@ export default function App() {
         <I18nProvider>
           <AppHeader />
           <main className="pb-8">
-            <Routes>
-              <Route path="/" element={<ConvertPage />} />
-              <Route path="/convert" element={<ConvertPage />} />
-              <Route path="/privacy" element={<PrivacyPage />} />
-              <Route path="/excel-addin" element={<AddinPage />} />
-              {localizedRoutes}
-              <Route path="*" element={<NotFoundPage />} />
-            </Routes>
+            <Suspense fallback={<div className="p-4 sm:p-6" />}>
+              <Routes>
+                <Route path="/" element={<ConvertPage />} />
+                <Route path="/convert" element={<ConvertPage />} />
+                <Route path="/privacy" element={<PrivacyPage />} />
+                <Route path="/excel-addin" element={<AddinPage />} />
+                {localizedRoutes}
+                <Route path="*" element={<NotFoundPage />} />
+              </Routes>
+            </Suspense>
           </main>
           <StatusBar />
         </I18nProvider>

--- a/frontend/src/pages/ConvertPage.tsx
+++ b/frontend/src/pages/ConvertPage.tsx
@@ -1,7 +1,6 @@
-import { type CSSProperties, useCallback, useEffect, useMemo, useState } from "react"
+import { lazy, Suspense, type CSSProperties, useCallback, useEffect, useMemo, useState } from "react"
 import { CheckCircle2, ClipboardPaste, FileText, Link2, LoaderCircle, Settings2, Table2 } from "lucide-react"
 
-import { CodeAssistEditor } from "@/components/CodeAssistEditor"
 import { ShareDialog } from "@/components/ShareDialog"
 import { CopyButton } from "@/components/convert/CopyButton"
 import { CsvActions } from "@/components/convert/CsvActions"
@@ -57,6 +56,21 @@ const SAMPLE = `x\ty1\ty2
 const OUTPUT_MIN_HEIGHT = 273
 const SITE_URL = "https://convertexcel.net/"
 const convertUrls = localizedSiteUrls(SITE_URL, "/")
+const CodeAssistEditor = lazy(() =>
+  import("@/components/CodeAssistEditor").then((module) => ({
+    default: module.CodeAssistEditor,
+  }))
+)
+
+function EditorFallback({ minHeight }: { minHeight: number }) {
+  return (
+    <div
+      className="rounded-md border bg-muted/30"
+      style={{ minHeight }}
+      aria-hidden="true"
+    />
+  )
+}
 
 export default function ConvertPage() {
   const { language, t, seo: seoText } = useI18n()
@@ -382,7 +396,9 @@ export default function ConvertPage() {
                   {cooldown > 0 && <span className="text-muted-foreground self-center text-sm">{t.convert.cooldown(cooldown)}</span>}
                 </div>
                 <div className={ghost}>
-                  <CodeAssistEditor kind="latex" value={latexOut} onChange={setLatexOut} minHeight={OUTPUT_MIN_HEIGHT} />
+                  <Suspense fallback={<EditorFallback minHeight={OUTPUT_MIN_HEIGHT} />}>
+                    <CodeAssistEditor kind="latex" value={latexOut} onChange={setLatexOut} minHeight={OUTPUT_MIN_HEIGHT} />
+                  </Suspense>
                 </div>
               </TabsContent>
               <TabsContent value="tikz" className="space-y-3">
@@ -413,7 +429,9 @@ export default function ConvertPage() {
                   />
                 )}
                 <div className={ghost}>
-                  <CodeAssistEditor kind="tikz" value={tikzOut} onChange={setTikzOut} minHeight={OUTPUT_MIN_HEIGHT} />
+                  <Suspense fallback={<EditorFallback minHeight={OUTPUT_MIN_HEIGHT} />}>
+                    <CodeAssistEditor kind="tikz" value={tikzOut} onChange={setTikzOut} minHeight={OUTPUT_MIN_HEIGHT} />
+                  </Suspense>
                 </div>
               </TabsContent>
               <TabsContent value="gnuplot" className="space-y-2">
@@ -438,7 +456,9 @@ export default function ConvertPage() {
                   <GnuplotSettingsPanel value={gnuplot} onChange={updateGnuplot} />
                 )}
                 <div className={ghost}>
-                  <CodeAssistEditor kind="gnuplot" value={gnuplotOut} onChange={setGnuplotOut} minHeight={OUTPUT_MIN_HEIGHT} />
+                  <Suspense fallback={<EditorFallback minHeight={OUTPUT_MIN_HEIGHT} />}>
+                    <CodeAssistEditor kind="gnuplot" value={gnuplotOut} onChange={setGnuplotOut} minHeight={OUTPUT_MIN_HEIGHT} />
+                  </Suspense>
                 </div>
               </TabsContent>
             </Tabs>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,44 @@
 import path from "node:path"
-import { defineConfig } from "vite"
+import { defineConfig, type Plugin } from "vite"
 import react from "@vitejs/plugin-react"
 import tailwindcss from "@tailwindcss/vite"
 
+function preloadEngineAssetsPlugin(): Plugin {
+  return {
+    name: "preload-engine-assets",
+    apply: "build",
+    enforce: "post",
+    transformIndexHtml(html, context) {
+      const bundle = context.bundle
+      if (!bundle) return html
+
+      const engineChunk = Object.values(bundle).find(
+        (item) => item.type === "chunk" && item.fileName.startsWith("assets/convertexcel_engine-")
+      )
+      const engineWasm = Object.values(bundle).find(
+        (item) => item.type === "asset" && item.fileName.startsWith("assets/convertexcel_engine_bg-")
+      )
+      const links = [
+        engineChunk
+          ? `    <link rel="modulepreload" crossorigin href="/${engineChunk.fileName}">`
+          : null,
+        engineWasm
+          ? `    <link rel="preload" href="/${engineWasm.fileName}" as="fetch" type="application/wasm" crossorigin>`
+          : null,
+      ].filter(Boolean)
+
+      if (links.length === 0) return html
+      return html.replace(
+        /(\s*<script type="module")/,
+        `\n${links.join("\n")}$1`
+      )
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), preloadEngineAssetsPlugin()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- add build-time preload links for the hashed frontend engine JS and WASM assets
- split route pages with React.lazy/Suspense
- lazy-load the CodeMirror-backed CodeAssistEditor behind a stable-height fallback

## Why
The frontend was shipping a large initial JavaScript bundle that included editor code and then loading the WASM engine after the main module started. This change reduces initial bundle pressure and starts fetching the engine assets earlier while preserving Vite's hashed asset filenames.

## Impact
- Initial route code is split from secondary pages.
- CodeMirror is moved into its own async chunk.
- The generated production HTML preloads the engine glue module and WASM file using the current hashed filenames.

## Validation
- `npm run build`
- `vite preview` opened with Playwright CLI at `http://127.0.0.1:4173`; main conversion UI and editor rendered successfully.
- The only console error observed was an existing `favicon.ico` 404.
