### PR TITLE
[codex] CMSのCloudflareビルドエラーを修正

### DIFF
--- a/cms/next.config.ts
+++ b/cms/next.config.ts
@@ -1,4 +1,8 @@
 import { withPayload } from '@payloadcms/next/withPayload'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -16,11 +20,24 @@ const nextConfig = {
   serverExternalPackages: ['jose', 'pg-cloudflare', 'pino', 'pino-pretty', 'pino-abstract-transport', 'thread-stream'],
 
   // Your Next.js config here
-  webpack: (webpackConfig: any) => {
+  webpack: (webpackConfig: any, { isServer }: { isServer: boolean }) => {
     webpackConfig.resolve.extensionAlias = {
       '.cjs': ['.cts', '.cjs'],
       '.js': ['.ts', '.tsx', '.js', '.jsx'],
       '.mjs': ['.mts', '.mjs'],
+    }
+
+    // storage-r2's client component imports the plugin-cloud-storage utilities
+    // barrel. That barrel also exports server-only helpers, causing webpack to
+    // pull Payload's Node dependencies into the browser admin bundle.
+    if (!isServer) {
+      webpackConfig.resolve.alias = {
+        ...webpackConfig.resolve.alias,
+        '@payloadcms/plugin-cloud-storage/utilities$': path.resolve(
+          dirname,
+          'src/lib/payload-cloud-storage-client.ts',
+        ),
+      }
     }
 
     return webpackConfig

--- a/cms/src/lib/payload-cloud-storage-client.ts
+++ b/cms/src/lib/payload-cloud-storage-client.ts
@@ -1,0 +1,63 @@
+type GetFileKeyArgs = {
+  collectionPrefix?: string
+  docPrefix?: string
+  filename: string
+  useCompositePrefixes?: boolean
+}
+
+const sanitizePrefix = (prefix: string): string => {
+  let decodedPrefix: string
+
+  try {
+    decodedPrefix = decodeURIComponent(prefix)
+  } catch {
+    return ''
+  }
+
+  if (/%[0-9a-f]{2}/i.test(decodedPrefix)) {
+    return ''
+  }
+
+  return decodedPrefix
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter((segment) => segment !== '..' && segment !== '.')
+    .join('/')
+    .replace(/^\/+/, '')
+    .replace(/[\x00-\x1f\x80-\x9f]/g, '')
+}
+
+const sanitizeFilename = (filename: string): string => {
+  const normalized = filename.replace(/\\/g, '/')
+  const basename = normalized.slice(normalized.lastIndexOf('/') + 1).replace(/[\x00-\x1f\x80-\x9f]/g, '')
+
+  if (!basename || basename === '.' || basename === '..') {
+    throw new Error('Invalid filename')
+  }
+
+  return basename
+}
+
+const joinKey = (...parts: string[]): string => parts.filter(Boolean).join('/').replace(/\/{2,}/g, '/')
+
+// Browser-safe equivalent of the helper used by @payloadcms/storage-r2.
+export const getFileKey = ({
+  collectionPrefix = '',
+  docPrefix = '',
+  filename,
+  useCompositePrefixes = false,
+}: GetFileKeyArgs) => {
+  const safeCollectionPrefix = sanitizePrefix(collectionPrefix)
+  const safeDocPrefix = sanitizePrefix(docPrefix)
+  const safeFilename = sanitizeFilename(filename)
+  const fileKey = useCompositePrefixes
+    ? joinKey(safeCollectionPrefix, safeDocPrefix, safeFilename)
+    : joinKey(safeDocPrefix || safeCollectionPrefix, safeFilename)
+
+  return {
+    fileKey,
+    sanitizedCollectionPrefix: safeCollectionPrefix,
+    sanitizedDocPrefix: safeDocPrefix,
+    sanitizedFilename: safeFilename,
+  }
+}


### PR DESCRIPTION
## 概要

Payload CMS の管理画面を Cloudflare 向けにビルドした際、Node.js 組み込みモジュールを解決できず失敗する問題を修正します。

## 変更内容

- クライアントビルド時のみ `@payloadcms/plugin-cloud-storage/utilities` をブラウザ向け実装へ差し替え
- R2 クライアントアップロードに必要な `getFileKey` をブラウザ安全な依存関係で実装
- サーバー側の Payload / R2 処理は従来のパッケージ実装を維持

## 原因

`@payloadcms/storage-r2` のクライアントコンポーネントが Cloud Storage の utilities バレルを参照していました。このバレルからサーバー専用コードも辿られ、`payload`、`undici`、`pino` 経由で `worker_threads` や `node:assert` などがブラウザ用 Webpack バンドルへ混入していました。

`nodejs_compat` は Worker ランタイム向けの設定であり、ブラウザ用バンドルの Node.js 依存関係は解決できません。

## 影響

- Cloudflare Pages / Workers の CMS ビルドが完了するようになります
- 管理画面からの R2 メディア操作で使用するキー生成仕様は維持されます

## 確認

- `npm run build:cf`
  - Next.js のコンパイル成功
  - OpenNext の Worker バンドル生成成功

既存コードに由来する未使用変数および `any` の lint warning は残りますが、ビルドエラーはありません。
